### PR TITLE
Echo to Error-Stream and double quotes

### DIFF
--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -5,36 +5,36 @@ alias cless='colorize_via_pygmentize_less'
 colorize_via_pygmentize() {
     local available_tools=("chroma" "pygmentize")
 
-    if [ -z $ZSH_COLORIZE_TOOL ]; then
+    if [ -z "$ZSH_COLORIZE_TOOL" ]; then
         if (( $+commands[pygmentize] )); then
             ZSH_COLORIZE_TOOL="pygmentize"
         elif (( $+commands[chroma] )); then
             ZSH_COLORIZE_TOOL="chroma"
         else
-            echo "Neither 'pygments' nor 'chroma' is installed!"
+            echo "Neither 'pygments' nor 'chroma' is installed!" >&2
             return 1
         fi
     fi
 
     if [[ ${available_tools[(Ie)$ZSH_COLORIZE_TOOL]} -eq 0 ]]; then
-        echo "ZSH_COLORIZE_TOOL '$ZSH_COLORIZE_TOOL' not recognized. Available options are 'pygmentize' and 'chroma'."
+        echo "ZSH_COLORIZE_TOOL '$ZSH_COLORIZE_TOOL' not recognized. Available options are 'pygmentize' and 'chroma'." >&2
         return 1
     elif (( $+commands["$ZSH_COLORIZE_TOOL"] )); then
-        echo "Package '$ZSH_COLORIZE_TOOL' is not installed!"
+        echo "Package '$ZSH_COLORIZE_TOOL' is not installed!" >&2
         return 1
     fi
 
     # If the environment variable ZSH_COLORIZE_STYLE
     # is set, use that theme instead. Otherwise,
     # use the default.
-    if [ -z $ZSH_COLORIZE_STYLE ]; then
+    if [ -z "$ZSH_COLORIZE_STYLE" ]; then
         # Both pygmentize & chroma support 'emacs'
         ZSH_COLORIZE_STYLE="emacs"
     fi
 
     # pygmentize stdin if no arguments passed
     if [ $# -eq 0 ]; then
-        if [[ $ZSH_COLORIZE_TOOL == "pygmentize" ]]; then
+        if [[ "$ZSH_COLORIZE_TOOL" == "pygmentize" ]]; then
             pygmentize -O style="$ZSH_COLORIZE_STYLE" -g
         else
             chroma --style="$ZSH_COLORIZE_STYLE"
@@ -48,7 +48,7 @@ colorize_via_pygmentize() {
     local FNAME lexer
     for FNAME in "$@"
     do
-        if [[ $ZSH_COLORIZE_TOOL == "pygmentize" ]]; then
+        if [[ "$ZSH_COLORIZE_TOOL" == "pygmentize" ]]; then
             lexer=$(pygmentize -N "$FNAME")
             if [[ $lexer != text ]]; then
                 pygmentize -O style="$ZSH_COLORIZE_STYLE" -l "$lexer" "$FNAME"


### PR DESCRIPTION
Based on your commit b776f1d20f0537cefec9b58e41933dfd04334b62 I added some minor fixes.
- Echo to Error-Stream
- Double quote to prevent globbing and word splitting